### PR TITLE
Feature/add additional fields for subscription entity

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Mock of Stripe's HttpClient which can be used in testing purposes in order to test your code and not to perform actual HTTP requests",
     "type": "library",
     "license": "MIT",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "php": ">=8.0",
     "autoload": {
         "psr-4": {

--- a/src/Entity/Subscription.php
+++ b/src/Entity/Subscription.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Readdle\StripeHttpClientMock\Entity;
 
+use DateTime;
 use Exception;
 use Readdle\StripeHttpClientMock\Collection;
 use Readdle\StripeHttpClientMock\EntityManager;
@@ -138,6 +139,15 @@ class Subscription extends AbstractEntity
                 ),
                 'currency' => $entity->props['currency'],
             ]);
+        }
+
+        if (
+            empty($entity->props['current_period_start']) &&
+            empty($entity->props['current_period_end'])
+        ) {
+            $dt = new DateTime('now');
+            $entity->props['current_period_start'] = $dt->getTimestamp();
+            $entity->props['current_period_end'] = $dt->modify('+1 year')->getTimestamp();
         }
 
         return $entity;

--- a/tests/Unit/Entity/SubscriptionTest.php
+++ b/tests/Unit/Entity/SubscriptionTest.php
@@ -1,0 +1,47 @@
+<?php
+declare(strict_types=1);
+
+namespace Unit\Entity;
+
+use DateTime;
+use Exception;
+use PHPUnit\Framework\TestCase;
+use Readdle\StripeHttpClientMock\Entity\Customer;
+use Readdle\StripeHttpClientMock\Entity\Subscription;
+
+class SubscriptionTest extends TestCase
+{
+    /**
+     * @throws Exception
+     */
+    public function testSubscriptionHasDefaultPeriod()
+    {
+        $customer = Customer::create('cus_123');
+        $subscription = Subscription::create('sub_123', [
+            'customer' => $customer->id
+        ]);
+
+        $this->assertNotNull($subscription->current_period_start);
+        $this->assertNotNull($subscription->current_period_end);
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testSubscriptionSupportsCustomPeriod()
+    {
+        $dt = new DateTime('now');
+        $periodStart = $dt->getTimestamp();
+        $periodEnd = $dt->modify('+30 days')->getTimestamp();
+
+        $customer = Customer::create('cus_123');
+        $subscription = Subscription::create('sub_123', [
+            'customer' => $customer->id,
+            'current_period_start' => $periodStart,
+            'current_period_end' => $periodEnd
+        ]);
+
+        $this->assertEquals($periodStart, $subscription->current_period_start);
+        $this->assertEquals($periodEnd, $subscription->current_period_end);
+    }
+}


### PR DESCRIPTION
Changes:
- Added next properties for Subscription Entity:
`current_period_start`: https://stripe.com/docs/api/subscriptions/object#subscription_object-current_period_start
`current_period_end`: https://stripe.com/docs/api/subscriptions/object#subscription_object-current_period_end 
- Added Unit test;
