### PR TITLE
Add Visa success card to test card registry 

### DIFF
--- a/src/Entity/PaymentIntent.php
+++ b/src/Entity/PaymentIntent.php
@@ -21,6 +21,7 @@ class PaymentIntent extends AbstractEntity
         'cancellation_reason'         => null,
         'capture_method'              => '',
         'charges'                     => [],
+        'latest_charge'               => null,
         'client_secret'               => '',
         'confirmation_method'         => '',
         'created'                     => 0,

--- a/src/TestCards/TestCardRegistry.php
+++ b/src/TestCards/TestCardRegistry.php
@@ -6,6 +6,7 @@ namespace Readdle\StripeHttpClientMock\TestCards;
 use Readdle\StripeHttpClientMock\TestCards\TestCard\ScaVerificationFlowRequired;
 use Readdle\StripeHttpClientMock\TestCards\TestCard\TestCardInterface;
 use Readdle\StripeHttpClientMock\TestCards\TestCard\VisaChargeDeclined;
+use Readdle\StripeHttpClientMock\TestCards\TestCard\VisaSuccess;
 
 /**
  * User: tarjei
@@ -20,7 +21,8 @@ class TestCardRegistry
     {
         $this->cards = [
             new VisaChargeDeclined(),
-            new ScaVerificationFlowRequired()
+            new ScaVerificationFlowRequired(),
+            new VisaSuccess()
         ];
     }
 


### PR DESCRIPTION
so that last_charge can be correctly set on payment intents when they get confirmed.