### PR TITLE
Library returns boolean as string true/false after object update

### DIFF
--- a/src/Entity/Subscription.php
+++ b/src/Entity/Subscription.php
@@ -20,7 +20,7 @@ class Subscription extends AbstractEntity
         'billing_cycle_anchor'              => null,
         'billing_thresholds'                => null,
         'cancel_at'                         => null,
-        'cancel_at_period_end'              => null,
+        'cancel_at_period_end'              => false,
         'canceled_at'                       => null,
         'collection_method'                 => null,
         'created'                           => null,


### PR DESCRIPTION
Subscription.cancel_at_period_end is a required boolean. If it is a NULL, check src/Entity/AbstractEntity::64 is not working